### PR TITLE
Support for Ubuntu 21.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ sudo dkms install cm4io-fan/0.1.0
 ```
 dtoverlay=cm4io-fan,minrpm=1000,maxrpm=5000
 ```
+5. Some distributions may not load the kernel module automatically (such as Ubuntu).  In order to load the module, you may need
+   to add it to `/etc/modules`, or make a new file called `/etc/modules-load.d/cm4io-fan.conf` with the contents:
+```
+emc2301
+```
 
 ## Install from git
 1. Install dkms if you haven't already:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 kernel module and device tree overlay to add support for the EMC2301 fan controller on the Raspberry Pi Compute Module 4 IO Board.
 
-*Works with 5.10.y 64-bit kernels only.*
+*Works with 5.10.y and 5.13.y 64-bit kernels only.*
 
 Uses Traverse Technologies' EMC2301 [hwmon driver](https://gitlab.traverse.com.au/ls1088firmware/traverse-sensors) for their [ten64](https://www.crowdsupply.com/traverse-technologies/ten64) board, which you should definitely check out because it's awesome.
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="cm4io-fan"
 PACKAGE_VERSION="0.1.1"
-BUILD_EXCLUSIVE_KERNEL="^5.[10-].*"
+BUILD_EXCLUSIVE_KERNEL="^5\.(10|13)\..*"
 
 MAKE="make"
 CLEAN="make clean"

--- a/dkms.post_install
+++ b/dkms.post_install
@@ -7,7 +7,8 @@ install_dt_overlay()
     local PWD=$(eval pwd)
     local overlay=$1
     local base_dir="${PWD%/*}/$kernelver/$arch/module"
-    local overlays_dir="/boot/overlays"
+    source /etc/default/rpi-eeprom-update
+    local overlays_dir="${BOOTFS:-/boot}/overlays"
 
     echo "$overlay:"
     echo " - Installation"

--- a/dkms.post_remove
+++ b/dkms.post_remove
@@ -3,7 +3,8 @@
 remove_dt_overlay()
 {
     local overlay=$1
-    local overlays_dir="/boot/overlays"
+    source /etc/default/rpi-eeprom-update
+    local overlays_dir="${BOOTFS:-/boot}/overlays"
 
     echo "${overlay}:"
     echo " - Uninstallation"


### PR DESCRIPTION
# Context 

Ubuntu stores overlays under `/boot/firmware/overlays`, instead of just `/boot/overlays` like many other operating systems for the Pi.  The location of the folder where `overlays` can be found is defined in `/etc/default/rpi-eeprom-update`.

Ubuntu 21.10, which is the suggested version of Ubuntu Server to install for the CM4, uses kernel 5.13.  This builds just fine on 5.13 (and probably 5.11 and 5.12 too).

# Changes

* post-install and post-remove scripts check `/etc/default/rpi-eeprom-update` for `BOOTFS` variable, and default to `/boot` if
not defined there to properly install the overlay on Ubuntu
* updates `BUILD_EXCLUSIVE_KERNEL` regex and `README.md` to support 5.13.y in addition to 5.10.y

# Additional Notes

DKMS will build it, and place it under `/lib/modules/5.13.0-1010-raspi/updates/dkms/emc2301.ko`.  At this point, the module can be manually loaded with `insmod`, and the fan is properly controlled.  However, it does not load automatically at boot unless one tells Ubuntu to do so.  I did so by adding a file under `/etc/modules-load.d/` called `cm4fan.conf` with a single line in it containing the text `emc2301`.