### PR TITLE
Support Linux kernel version 6

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="cm4io-fan"
 PACKAGE_VERSION="0.2.0"
-# allow anything 5.10 thru 5.99, which should be fine...
-BUILD_EXCLUSIVE_KERNEL="^5\.([1-9][0-9])\..*"
+# allow anything 5.10 thru 5.99, and 6 which should be fine...
+BUILD_EXCLUSIVE_KERNEL="^((5\.([1-9][0-9])\.)|(6\.)).*"
 
 MAKE="make"
 CLEAN="make clean"


### PR DESCRIPTION
I could not run `sudo dkms install cm4io-fan/0.2.0` without allowing DKMS to run on a Linux Kernel `6.1.21-v8+`.

This change add all version 6 kernels to the allowed list.